### PR TITLE
feat(StringLiteral): Add support for embedded quotes in string literals

### DIFF
--- a/src/ast/StringLiteral.js
+++ b/src/ast/StringLiteral.js
@@ -31,9 +31,10 @@ function createNode(value, position) {
     function stripQuotes(value) {
         if ((value[0] === '\'' && value[value.length - 1] === '\'') ||
             (value[0] === '"' && value[value.length - 1] === '"')) {
-            return value.substring(1, value.length - 1);
+            value = value.substring(1, value.length - 1);
         }
-        return value;
+
+        return value.replace(/''/g, '\'').replace(/""/g, '"');
     }
 
     //value cannot be null so no check

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -43,6 +43,26 @@ describe('spel expression evaluator', ()=>{
                 expect(stringDouble).toBe('hello world!');
             });
 
+            it('should evaluate a string with embedded escaped single quotes', ()=>{
+                //when
+                let stringSingle = evaluator.eval('\'hello \'\'world\'\'!\'');
+                let stringDouble = evaluator.eval('"hello \'\'world\'\'!"');
+
+                //then
+                expect(stringSingle).toBe('hello \'world\'!');
+                expect(stringDouble).toBe('hello \'world\'!');
+            });
+
+            it('should evaluate a string with embedded escaped double quotes', ()=>{
+                //when
+                let stringSingle = evaluator.eval('\'hello ""world""!\'');
+                let stringDouble = evaluator.eval('"hello ""world""!"');
+
+                //then
+                expect(stringSingle).toBe('hello "world"!');
+                expect(stringDouble).toBe('hello "world"!');
+            });
+
             it('should evaluate a boolean', ()=>{
                 //when
                 let boolTrue = evaluator.eval('true');


### PR DESCRIPTION
https://docs.spring.io/spring/docs/current/spring-framework-reference/html/expressions.html#expressions-ref-literal

> Strings are delimited by single quotes. To put a single quote itself in a string, use two single quote characters.
