### PR TITLE
feat(parser): Add implementations (that simply throw an error) for all "not implemented" tokens

### DIFF
--- a/src/SpelExpressionParser.js
+++ b/src/SpelExpressionParser.js
@@ -53,6 +53,7 @@ import {OpDec} from './ast/OpDec';
 import {OpNot} from './ast/OpNot';
 import {OpAnd} from './ast/OpAnd';
 import {OpOr} from './ast/OpOr';
+import {OperatorMatches} from "./ast/OperatorMatches";
 import {Ternary} from './ast/Ternary';
 import {Elvis} from './ast/Elvis';
 import {InlineList} from './ast/InlineList';
@@ -61,15 +62,13 @@ import {Selection} from './ast/Selection';
 import {Projection} from './ast/Projection';
 
 //not yet implemented
-var OperatorInstanceof,
-    OperatorMatches,
-    OperatorBetween,
-    BeanReference,
-    TypeReference,
-    QualifiedIdentifier,
-    Identifier,
-    ConstructorReference;
-
+import {OperatorInstanceof} from "./ast/OperatorInstanceof";
+import {OperatorBetween} from "./ast/OperatorBetween";
+import {TypeReference} from "./ast/TypeReference";
+import {BeanReference} from "./ast/BeanReference";
+import {Identifier} from "./ast/Identifier";
+import {QualifiedIdentifier} from "./ast/QualifiedIdentifier";
+import {ConstructorReference} from "./ast/ConstructorReference";
 
 export var SpelExpressionParser = function () {
 
@@ -224,15 +223,15 @@ export var SpelExpressionParser = function () {
             }
 
             if (tk === TokenKind.INSTANCEOF) {
-                return new OperatorInstanceof(toPosToken(token), expr, rhExpr);
+                return OperatorInstanceof.create(toPosToken(token), expr, rhExpr);
             }
 
             if (tk === TokenKind.MATCHES) {
-                return new OperatorMatches(toPosToken(token), expr, rhExpr);
+                return OperatorMatches.create(toPosToken(token), expr, rhExpr);
             }
 
             //Assert.isTrue(tk === TokenKind.BETWEEN);
-            return new OperatorBetween(toPosToken(token), expr, rhExpr);
+            return OperatorBetween.create(toPosToken(token), expr, rhExpr);
         }
         return expr;
     }
@@ -526,7 +525,7 @@ export var SpelExpressionParser = function () {
                 raiseInternalException(beanRefToken.startPos, 'INVALID_BEAN_REFERENCE');
             }
 
-            var beanReference = new BeanReference(toPosToken(beanNameToken), beanName);
+            var beanReference = BeanReference.create(toPosToken(beanNameToken), beanName);
             push(beanReference);
             return true;
         }
@@ -556,7 +555,7 @@ export var SpelExpressionParser = function () {
                 dims++;
             }
             eatToken(TokenKind.RPAREN);
-            push(new TypeReference(toPosToken(typeName), node, dims));
+            push(TypeReference.create(toPosToken(typeName), node, dims));
             return true;
         }
         return false;
@@ -693,7 +692,7 @@ export var SpelExpressionParser = function () {
         while (isValidQualifiedId(node)) {
             nextToken();
             if (node.kind !== TokenKind.DOT) {
-                qualifiedIdPieces.push(new Identifier(node.stringValue(), toPosToken(node)));
+                qualifiedIdPieces.push(Identifier.create(node.stringValue(), toPosToken(node)));
             }
             node = peekToken();
         }
@@ -704,7 +703,7 @@ export var SpelExpressionParser = function () {
             raiseInternalException(node.startPos, 'NOT_EXPECTED_TOKEN', 'qualified ID', node.getKind().toString().toLowerCase());
         }
         var pos = toPosBounds(qualifiedIdPieces[0].getStartPosition(), qualifiedIdPieces[qualifiedIdPieces.length - 1].getEndPosition());
-        return new QualifiedIdentifier(pos, qualifiedIdPieces);
+        return QualifiedIdentifier.create(pos, qualifiedIdPieces);
     }
 
     function isValidQualifiedId(node) {
@@ -766,13 +765,13 @@ export var SpelExpressionParser = function () {
                 if (maybeEatInlineListOrMap()) {
                     nodes.push(pop());
                 }
-                push(new ConstructorReference(toPosToken(newToken), dimensions, nodes));
+                push(ConstructorReference.create(toPosToken(newToken), dimensions, nodes));
             }
             else {
                 // regular constructor invocation
                 eatConstructorArgs(nodes);
                 // TODO correct end position?
-                push(new ConstructorReference(toPosToken(newToken), nodes));
+                push(ConstructorReference.create(toPosToken(newToken), nodes));
             }
             return true;
         }

--- a/src/ast/BeanReference.js
+++ b/src/ast/BeanReference.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * Represents a bean reference to a type, for example <tt>@foo</tt> or <tt>@'foo.bar'</tt>.
+ * For a FactoryBean the syntax <tt>&foo</tt> can be used to access the factory itself.
+ *
+ * @author Andy Clement
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('beanref', position, left, right);
+
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'BeanReference: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var BeanReference =  {
+    create: createNode
+};

--- a/src/ast/ConstructorReference.js
+++ b/src/ast/ConstructorReference.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * Represents the invocation of a constructor. Either a constructor on a regular type or
+ * construction of an array. When an array is constructed, an initializer can be specified.
+ *
+ * <p>Examples:<br>
+ * new String('hello world')<br>
+ * new int[]{1,2,3,4}<br>
+ * new int[3] new int[3]{1,2,3}
+ *
+ * @author Andy Clement
+ * @author Juergen Hoeller
+ * @since 3.0
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('constructorref', position, left, right);
+
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'BeanReference: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var ConstructorReference =  {
+    create: createNode
+};

--- a/src/ast/Identifier.js
+++ b/src/ast/Identifier.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * An 'identifier' {@link SpelNode}.
+ *
+ * @author Andy Clement
+ * @since 3.0
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('identifier', position, left, right);
+
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'Identifier: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var Identifier =  {
+    create: createNode
+};

--- a/src/ast/OperatorBetween.js
+++ b/src/ast/OperatorBetween.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * Represents the between operator. The left operand to between must be a single value and
+ * the right operand must be a list - this operator returns true if the left operand is
+ * between (using the registered comparator) the two elements in the list. The definition
+ * of between being inclusive follows the SQL BETWEEN definition.
+ *
+ * @author Andy Clement
+ * @since 3.0
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('between', position, left, right);
+
+    /**
+     * Returns a boolean based on whether a value is in the range expressed. The first
+     * operand is any value whilst the second is a list of two values - those two values
+     * being the bounds allowed for the first operand (inclusive).
+     * @param state the expression state
+     * @return true if the left operand is in the range specified, false otherwise
+     * @throws EvaluationException if there is a problem evaluating the expression
+     */
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'OperatorBetween: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var OperatorBetween =  {
+    create: createNode
+};

--- a/src/ast/OperatorInstanceof.js
+++ b/src/ast/OperatorInstanceof.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * The operator 'instanceof' checks if an object is of the class specified in the right
+ * hand operand, in the same way that {@code instanceof} does in Java.
+ *
+ * THIS OPERATOR IS NOT IMPLEMENTED AND WILL THROW AN EXCEPTION
+ *
+ * @author Andy Clement
+ * @since 3.0
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('instanceof', position, left, right);
+
+    /**
+     * Compare the left operand to see it is an instance of the type specified as the
+     * right operand. The right operand must be a class.
+     * @param state the expression state
+     * @return {@code true} if the left operand is an instanceof of the right operand,
+     * otherwise {@code false}
+     * @throws EvaluationException if there is a problem evaluating the expression
+     */
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'OperatorInstanceOf: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var OperatorInstanceof =  {
+    create: createNode
+};

--- a/src/ast/OperatorMatches.js
+++ b/src/ast/OperatorMatches.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * Implements the matches operator. Matches takes two operands:
+ * The first is a String and the second is a Java regex.
+ * It will return {@code true} when {@link #getValue} is called
+ * if the first operand matches the regex.
+ *
+ * @author Andy Clement
+ * @author Juergen Hoeller
+ * @author Chris Thielen
+ * @since 3.0
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('matches', position, left, right);
+
+    /**
+     * Check the first operand matches the regex specified as the second operand.
+     * @param state the expression state
+     * @return {@code true} if the first operand matches the regex specified as the
+     * second operand, otherwise {@code false}
+     * @throws EvaluationException if there is a problem evaluating the expression
+     * (e.g. the regex is invalid)
+     */
+    node.getValue = function (state) {
+        var data = left.getValue(state);
+        var regexpString = right.getValue(state);
+
+        try {
+            var regexp = new RegExp(regexpString);
+            return !!regexp.exec(data)
+        } catch (error) {
+            throw {
+                name: 'EvaluationException',
+                message: error.toString()
+            }
+        }
+    };
+
+    return node;
+}
+
+export var OperatorMatches =  {
+    create: createNode
+};

--- a/src/ast/QualifiedIdentifier.js
+++ b/src/ast/QualifiedIdentifier.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * Represents a dot separated sequence of strings that indicate a package qualified type
+ * reference.
+ *
+ * <p>Example: "java.lang.String" as in the expression "new java.lang.String('hello')"
+ *
+ * @author Andy Clement
+ * @since 3.0
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('qualifiedidentifier', position, left, right);
+
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'QualifiedIdentifier: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var QualifiedIdentifier =  {
+    create: createNode
+};

--- a/src/ast/TypeReference.js
+++ b/src/ast/TypeReference.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SpelNode} from './SpelNode';
+
+/**
+ * Represents a reference to a type, for example
+ * {@code "T(String)" or "T(com.somewhere.Foo)"}.
+ *
+ * @author Andy Clement
+ */
+function createNode(position, left, right) {
+    var node = SpelNode.create('typeref', position, left, right);
+
+    node.getValue = function (state) {
+        throw {
+            name: 'MethodNotImplementedException',
+            message: 'TypeReference: Not implemented'
+        }
+    };
+
+    return node;
+}
+
+export var TypeReference =  {
+    create: createNode
+};

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -418,6 +418,36 @@ describe('spel expression evaluator', ()=>{
 
         });
 
+        describe('matches', ()=>{
+
+            it('should return true if the left side matches the regexp string on the right side', ()=>{
+                //when
+                let matches = evaluator.eval('"the quick brown fox" matches "^the.*fox$"');
+
+                //then
+                expect(matches).toBe(true);
+            });
+
+            it('should return false if the left side does not match the regexp string on the right side', ()=>{
+                //when
+                let matches = evaluator.eval('"the quick brown dog" matches "^the.*fox$"');
+
+                //then
+                expect(matches).toBe(false);
+            });
+
+
+            it('should throw if the regexp is invalid', ()=>{
+                //when
+                let willthrow = ()=>evaluator.eval('"foo" matches "["');
+
+                //then
+                expect(willthrow).toThrow();
+            });
+
+
+        });
+
 
         describe('ternary', ()=>{
 


### PR DESCRIPTION
Also adds a naive javascript implementation for `OperatorMatches`.

The intention here is to allow spel2js to _parse_ an expression, even if it cannot _evaluate_ that expression.  This moves the error to the evaluation phase.

I'd like to use spel2js to do client-side syntax validation of expressions that are evaluated serverside by Spring.  The unimplemented tokens being `undefined` references is causing parsing itself to fail.  

@benmarch PTAL, are you still maintaining this repo?
