### PR TITLE
Fixed compiling of constructor and type reference. Fixed unary plus/minus. Added node.getRaw().

### DIFF
--- a/src/SpelExpressionParser.js
+++ b/src/SpelExpressionParser.js
@@ -714,7 +714,7 @@ export var SpelExpressionParser = function () {
             return true;
         }
         var value = node.stringValue();
-        return (value.length && VALID_QUALIFIED_ID_PATTERN.test(value));
+        return (value && value.length && VALID_QUALIFIED_ID_PATTERN.test(value));
     }
 
     // This is complicated due to the support for dollars in identifiers.  Dollars are normally separate tokens but

--- a/src/ast/BeanReference.js
+++ b/src/ast/BeanReference.js
@@ -22,8 +22,8 @@ import {SpelNode} from './SpelNode';
  *
  * @author Andy Clement
  */
-function createNode(position, left, right) {
-    var node = SpelNode.create('beanref', position, left, right);
+function createNode(position, beanName) {
+    var node = SpelNode.create('beanref', position);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/ConstructorReference.js
+++ b/src/ast/ConstructorReference.js
@@ -29,13 +29,26 @@ import {SpelNode} from './SpelNode';
  * @author Juergen Hoeller
  * @since 3.0
  */
-function createNode(position, nodes) {
-    var node = SpelNode.create('constructorref', position);
+ function createNode(position, dimensions, nodes) {
+    var isArray = nodes !== undefined;
+    var dimension;
+    if (isArray) {
+        dimension = dimensions.length && dimensions[0] && dimensions[0].type === 'number' ? dimensions[0].getValue() : null;
+    } else {
+        nodes = dimensions;
+        dimensions = undefined;
+    }
+    
+    var node = SpelNode.create('constructorref', position, ...nodes);
+
+    node.getRaw = function () {
+        return dimension;
+    };
 
     node.getValue = function (state) {
         throw {
             name: 'MethodNotImplementedException',
-            message: 'BeanReference: Not implemented'
+            message: 'ConstructorReference: Not implemented'
         }
     };
 

--- a/src/ast/ConstructorReference.js
+++ b/src/ast/ConstructorReference.js
@@ -29,8 +29,8 @@ import {SpelNode} from './SpelNode';
  * @author Juergen Hoeller
  * @since 3.0
  */
-function createNode(position, left, right) {
-    var node = SpelNode.create('constructorref', position, left, right);
+function createNode(position, nodes) {
+    var node = SpelNode.create('constructorref', position);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/ConstructorReference.js
+++ b/src/ast/ConstructorReference.js
@@ -15,6 +15,7 @@
  */
 
 import {SpelNode} from './SpelNode';
+import {Stack} from '../lib/Stack';
 
 /**
  * Represents the invocation of a constructor. Either a constructor on a regular type or
@@ -33,11 +34,12 @@ import {SpelNode} from './SpelNode';
     var isArray = nodes !== undefined;
     var dimension;
     if (isArray) {
-        dimension = dimensions.length && dimensions[0] && dimensions[0].type === 'number' ? dimensions[0].getValue() : null;
+        dimension = dimensions.length && dimensions[0] && dimensions[0].getType() === 'number' ? dimensions[0].getValue() : null;
     } else {
         nodes = dimensions;
         dimensions = undefined;
     }
+    const [_qualifiedIdentifier, ...args] = nodes;
     
     var node = SpelNode.create('constructorref', position, ...nodes);
 
@@ -46,6 +48,30 @@ import {SpelNode} from './SpelNode';
     };
 
     node.getValue = function (state) {
+        if (isArray && args.length <= 1) {
+            var compiledArgs = [];
+
+            //populate arguments
+            args.forEach(function (arg) {
+                // reset the active context to root context for evaluating argument
+                const currentActiveContext = state.activeContext
+                state.activeContext = new Stack();
+                state.activeContext.push(state.rootContext);
+
+                // evaluate argument
+                compiledArgs.push(arg.getValue(state));
+
+                // reset the active context
+                state.activeContext = currentActiveContext;
+            });
+
+            if (args.length == 1) {
+                return compiledArgs[0];
+            } else {
+                return dimension ? new Array(dimension) : [];
+            }
+        }
+
         throw {
             name: 'MethodNotImplementedException',
             message: 'ConstructorReference: Not implemented'

--- a/src/ast/ConstructorReference.js
+++ b/src/ast/ConstructorReference.js
@@ -65,7 +65,7 @@ import {Stack} from '../lib/Stack';
                 state.activeContext = currentActiveContext;
             });
 
-            if (args.length == 1) {
+            if (args.length === 1) {
                 return compiledArgs[0];
             } else {
                 return dimension ? new Array(dimension) : [];

--- a/src/ast/FunctionReference.js
+++ b/src/ast/FunctionReference.js
@@ -36,6 +36,13 @@ import {Stack} from '../lib/Stack';
 function createNode(functionName, position, args) {
     var node = SpelNode.create('function', position);
 
+    node.getRaw = function () {
+        return {
+            functionName,
+            args
+        };
+    };
+
     node.getValue = function (state) {
         var locals = state.locals || {},
             context = state.rootContext,

--- a/src/ast/Identifier.js
+++ b/src/ast/Identifier.js
@@ -22,8 +22,8 @@ import {SpelNode} from './SpelNode';
  * @author Andy Clement
  * @since 3.0
  */
-function createNode(position, left, right) {
-    var node = SpelNode.create('identifier', position, left, right);
+function createNode(identifierName, position) {
+    var node = SpelNode.create('identifier', position);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/Identifier.js
+++ b/src/ast/Identifier.js
@@ -25,6 +25,10 @@ import {SpelNode} from './SpelNode';
 function createNode(identifierName, position) {
     var node = SpelNode.create('identifier', position);
 
+    node.getRaw = function () {
+        return identifierName;
+    };
+
     node.getValue = function (state) {
         throw {
             name: 'MethodNotImplementedException',

--- a/src/ast/InlineList.js
+++ b/src/ast/InlineList.js
@@ -28,6 +28,10 @@ function createNode(position, elements) {
     var node = SpelNode.create('list', position),
         list = [].concat(elements || []);
 
+    node.getRaw = function () {
+        return list;
+    };
+    
     node.getValue = function (state) {
         return list.map(function (element) {
             return element.getValue(state);

--- a/src/ast/MethodReference.js
+++ b/src/ast/MethodReference.js
@@ -30,6 +30,13 @@ import {Stack} from '../lib/Stack'
 function createNode(nullSafeNavigation, methodName, position, args) {
     var node = SpelNode.create('method', position);
 
+    node.getRaw = function () {
+        return {
+            methodName,
+            args
+        };
+    };
+
     node.getValue = function (state) {
         var context = state.activeContext.peek(),
             compiledArgs = [],

--- a/src/ast/OpMinus.js
+++ b/src/ast/OpMinus.js
@@ -39,8 +39,9 @@ function createNode(position, left, right) {
     var node = SpelNode.create('op-minus', position, left, right);
 
     node.getValue = function (state) {
-        if (!right)
+        if (!right) {
             return - left.getValue(state);
+        }
         return left.getValue(state) - right.getValue(state);
     };
 

--- a/src/ast/OpMinus.js
+++ b/src/ast/OpMinus.js
@@ -39,6 +39,8 @@ function createNode(position, left, right) {
     var node = SpelNode.create('op-minus', position, left, right);
 
     node.getValue = function (state) {
+        if (!right)
+            return - left.getValue(state);
         return left.getValue(state) - right.getValue(state);
     };
 

--- a/src/ast/OpPlus.js
+++ b/src/ast/OpPlus.js
@@ -39,8 +39,9 @@ function createNode(position, left, right) {
     var node = SpelNode.create('op-plus', position, left, right);
 
     node.getValue = function (state) {
-        if (!right)
+        if (!right) {
             return + left.getValue(state);
+        }
         //javascript will handle string concatenation or addition depending on types
         return left.getValue(state) + right.getValue(state);
     };

--- a/src/ast/OpPlus.js
+++ b/src/ast/OpPlus.js
@@ -39,6 +39,8 @@ function createNode(position, left, right) {
     var node = SpelNode.create('op-plus', position, left, right);
 
     node.getValue = function (state) {
+        if (!right)
+            return + left.getValue(state);
         //javascript will handle string concatenation or addition depending on types
         return left.getValue(state) + right.getValue(state);
     };

--- a/src/ast/PropertyReference.js
+++ b/src/ast/PropertyReference.js
@@ -29,6 +29,10 @@ import {SpelNode} from './SpelNode';
 function createNode(nullSafeNavigation, propertyName, position) {
     var node = SpelNode.create('property', position);
 
+    node.getRaw = function () {
+        return propertyName;
+    };
+
     node.getValue = function (state) {
         var context = state.activeContext.peek();
 

--- a/src/ast/QualifiedIdentifier.js
+++ b/src/ast/QualifiedIdentifier.js
@@ -25,8 +25,8 @@ import {SpelNode} from './SpelNode';
  * @author Andy Clement
  * @since 3.0
  */
-function createNode(position, left, right) {
-    var node = SpelNode.create('qualifiedidentifier', position, left, right);
+function createNode(position, pieces) {
+    var node = SpelNode.create('qualifiedidentifier', position);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/QualifiedIdentifier.js
+++ b/src/ast/QualifiedIdentifier.js
@@ -28,6 +28,10 @@ import {SpelNode} from './SpelNode';
 function createNode(position, pieces) {
     var node = SpelNode.create('qualifiedidentifier', position, ...pieces);
 
+    node.getRaw = function () {
+        return pieces.map(p => p.getRaw());
+    };
+
     node.getValue = function (state) {
         throw {
             name: 'MethodNotImplementedException',

--- a/src/ast/QualifiedIdentifier.js
+++ b/src/ast/QualifiedIdentifier.js
@@ -26,7 +26,7 @@ import {SpelNode} from './SpelNode';
  * @since 3.0
  */
 function createNode(position, pieces) {
-    var node = SpelNode.create('qualifiedidentifier', position);
+    var node = SpelNode.create('qualifiedidentifier', position, ...pieces);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/SpelNode.js
+++ b/src/ast/SpelNode.js
@@ -43,6 +43,16 @@ function createSpelNode(nodeType, position, ...operands) {
         return children;
     };
     node.addChild = function (childNode) {
+        if (!childNode) {
+            // See OpMinus and OpPlus: right node can be null for unary mode
+            return;
+        }
+        if (!childNode.setParent) {
+            throw {
+                name: 'Error',
+                message: 'Trying to add a child which is not a node: ' + JSON.stringify(childNode)
+            };
+        }
         childNode.setParent(node);
         children.push(childNode);
     };

--- a/src/ast/TypeReference.js
+++ b/src/ast/TypeReference.js
@@ -22,8 +22,8 @@ import {SpelNode} from './SpelNode';
  *
  * @author Andy Clement
  */
-function createNode(position, left, right) {
-    var node = SpelNode.create('typeref', position, left, right);
+function createNode(position, node, dims) {
+    var node = SpelNode.create('typeref', position, node, dims);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/TypeReference.js
+++ b/src/ast/TypeReference.js
@@ -22,8 +22,8 @@ import {SpelNode} from './SpelNode';
  *
  * @author Andy Clement
  */
-function createNode(position, node, dims) {
-    var node = SpelNode.create('typeref', position, node, dims);
+function createNode(position, node, _dims) {
+    var node = SpelNode.create('typeref', position, node);
 
     node.getValue = function (state) {
         throw {

--- a/src/ast/VariableReference.js
+++ b/src/ast/VariableReference.js
@@ -28,6 +28,10 @@ import {SpelNode} from './SpelNode';
 function createNode(variableName, position) {
     var node = SpelNode.create('variable', position);
 
+    node.getRaw = function () {
+        return variableName;
+    };
+
     node.getValue = function (state) {
         var context = state.activeContext.peek(),
             locals = state.locals;

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -25,6 +25,22 @@ describe('spel expression evaluator', ()=>{
             expect(compiledExpression.eval).toBeDefined();
         });
 
+        it('should compile expression with array constructor without dimensions', ()=>{
+            //when
+            let compiledExpression = evaluator.compile('new int[]{1,2,3}');
+
+            //then
+            expect(compiledExpression.eval).toBeDefined();
+        });
+
+        it('should compile expression with array constructor with dimensions', ()=>{
+            //when
+            let compiledExpression = evaluator.compile('new int[3]{1,2,3}');
+
+            //then
+            expect(compiledExpression.eval).toBeDefined();
+        });
+
         it('should compile expression with type reference', ()=>{
             //when
             let compiledExpression = evaluator.compile('T(java.time.LocalTime).parse("11:22")');

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -865,6 +865,52 @@ describe('spel expression evaluator', ()=>{
 
         });
 
+        describe('constructor', ()=>{
+            it('should create new int array', ()=>{
+                //given
+                let context = {};
+
+                //when
+                let newArray = evaluator.eval('new int[]{1, 2, 3}', context);
+
+                //then
+                expect(newArray).toEqual([1, 2, 3]);
+            });
+
+            it('should create new int array with dimension', ()=>{
+                //given
+                let context = {};
+
+                //when
+                let newArray = evaluator.eval('new int[3]{1, 2, 3}', context);
+
+                //then
+                expect(newArray).toEqual([1, 2, 3]);
+            });
+
+            it('should create new empty array', ()=>{
+                //given
+                let context = {};
+
+                //when
+                let newArray = evaluator.eval('new int[]', context);
+
+                //then
+                expect(newArray).toEqual([]);
+            });
+
+            it('should create new empty array with dimension', ()=>{
+                //given
+                let context = {};
+
+                //when
+                let newArray = evaluator.eval('new int[3]', context);
+
+                //then
+                expect(newArray.length).toEqual(3);
+            });
+        });
+
     });
 
 });

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -60,10 +60,14 @@ describe('spel expression evaluator', ()=>{
                 //when
                 let numberInt = evaluator.eval('123');
                 let numberFloat = evaluator.eval('123.4');
+                let negativeNumberInt = evaluator.eval('-123');
+                let negativeNumberFloat = evaluator.eval('-123.4');
 
                 //then
                 expect(numberInt).toBe(123);
                 expect(numberFloat).toBe(123.4);
+                expect(negativeNumberInt).toBe(-123);
+                expect(negativeNumberFloat).toBe(-123.4);
             });
 
             it('should evaluate a string', ()=>{

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -17,6 +17,22 @@ describe('spel expression evaluator', ()=>{
             expect(compiledExpression.eval).toBeDefined();
         });
 
+        it('should compile expression with constructor', ()=>{
+            //when
+            let compiledExpression = evaluator.compile('new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2022-01-01")');
+
+            //then
+            expect(compiledExpression.eval).toBeDefined();
+        });
+
+        it('should compile expression with type reference', ()=>{
+            //when
+            let compiledExpression = evaluator.compile('T(java.time.LocalTime).parse("11:22")');
+
+            //then
+            expect(compiledExpression.eval).toBeDefined();
+        });
+
     });
 
 


### PR DESCRIPTION
1. Fixed error `Cannot read property 'setParent' of undefined` when trying to compile expression with constructor or type reference

```
new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2022-01-01")
T(java.time.LocalTime).parse("11:22")
```

2. Added support for array constructors
```
new int[]{1, 2, 3}
new int[3]{1, 2, 3}
```

3. Fixed urary plus/minus. Resolves issue https://github.com/benmarch/spel2js/issues/12

4. Added `node.getRaw()` for some types to get raw value (eg. `propertyName` for `property` node). 
Can be used for debugging compiled expressions.
Used in https://github.com/ukrbublik/react-awesome-query-builder to convert compiled expression to internal store format.

Added unit tests