### PR TITLE
Fix: Avoid throwing an error if context is an empty string, false, or 0

### DIFF
--- a/src/ast/MethodReference.js
+++ b/src/ast/MethodReference.js
@@ -42,7 +42,7 @@ function createNode(nullSafeNavigation, methodName, position, args) {
             compiledArgs = [],
             method;
 
-        if (!context) {
+        if (context === null || context === undefined) {
             throw {
                 name: 'ContextDoesNotExistException',
                 message: 'Attempting to look up property \''+ methodName +'\' for an undefined context.'

--- a/test/spec/SpelExpressionEvaluator.spec.js
+++ b/test/spec/SpelExpressionEvaluator.spec.js
@@ -127,7 +127,11 @@ describe('spel expression evaluator', ()=>{
                             hi: 'bye'
                         },
                         propLookup: 'Found!'
-                    }
+                    },
+                    emptyString: '',
+                    zeroNumber: 0,
+                    falseBool: false,
+                    normalString: 'hello'
                 };
             });
 
@@ -188,6 +192,31 @@ describe('spel expression evaluator', ()=>{
                 //then
                 expect(willThrow).toThrow();
                 expect(willBeNull).toBe(null);
+            });
+
+            it('should allow .toUpperCase() on empty string', () => {
+                const result = evaluator.eval('emptyString.toUpperCase()', context);
+                expect(result).toBe(''); // "" -> ""
+            });
+
+            it('should allow .toUpperCase() on normal string', () => {
+                const result = evaluator.eval('normalString.toUpperCase()', context);
+                expect(result).toBe('HELLO');
+            });
+
+            it('should allow .toString() on number 0', () => {
+                const result = evaluator.eval('zeroNumber.toString()', context);
+                expect(result).toBe('0');
+            });
+
+            it('should allow .toString() on boolean false', () => {
+                const result = evaluator.eval('falseBool.toString()', context);
+                expect(result).toBe('false');
+            });
+
+            it('should allow safe navigation on primitive method calls', () => {
+                const result = evaluator.eval('emptyString?.toUpperCase()', context);
+                expect(result).toBe('');
             });
         });
 


### PR DESCRIPTION
## Before

### empty string
<img width="1175" height="592" alt="image" src="https://github.com/user-attachments/assets/15513789-1c1b-4ab7-9449-3d6220d173df" />



### 0
<img width="1164" height="586" alt="image" src="https://github.com/user-attachments/assets/047cf084-9286-4f14-a0a0-ff285e642a46" />



### false
<img width="1177" height="662" alt="image" src="https://github.com/user-attachments/assets/ab8689c6-45bb-4ba6-bd7b-d59988bfd2f0" />


## After
### empty string
<img width="1162" height="620" alt="image" src="https://github.com/user-attachments/assets/750b1f23-4063-4c61-83da-eee0ada2b059" />


### 0
<img width="1174" height="631" alt="image" src="https://github.com/user-attachments/assets/66f8360a-2cd2-427a-b6a2-565b047afdb6" />


### false
<img width="1154" height="653" alt="image" src="https://github.com/user-attachments/assets/a423ea1d-dcd7-4be2-8f87-11a98ffbdc64" />
